### PR TITLE
 Exclude Jupyter Notebooks from `pretty-format-json` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       - id: detect-private-key
       - id: pretty-format-json
         args: ['--autofix', '--no-sort-keys', '--indent=4']
+        exclude: ".*\\.ipynb$"
       - id: end-of-file-fixer
       - id: mixed-line-ending
 


### PR DESCRIPTION
# Description

This PR updates `.pre-commit-config.yaml` to exclude Jupyter Notebook (`.ipynb`) files from being auto-formatted by the `pretty-format-json` hook. This prevents unwanted modifications to notebook JSON structure while maintaining formatting for standard JSON files.